### PR TITLE
`waf` command is replaced by `ns3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ git clone https://github.com/signetlabdei/ns-3-vr-app ns-3-dev/contrib/vr-app
 Configure and build ns-3 from the `ns-3-dev` folder:
 
 ```bash
-./waf configure --enable-tests --enable-examples
-./waf build
+./ns3 configure --enable-tests --enable-examples
+./ns3 build
 ```
 
 This module does not provide Python bindings at the moment.


### PR DESCRIPTION
In the commit https://gitlab.com/nsnam/ns-3-dev/-/commit/e32c177e45a24324a0e81844f0233b377115328f , `waf` command is replaced by `ns3`.